### PR TITLE
Updating push script to minify via webservice

### DIFF
--- a/push
+++ b/push
@@ -1,4 +1,5 @@
 docco microfiche.js
+curl --data-urlencode "js_code=$(cat $(git rev-parse --show-toplevel)/microfiche.js)" http://marijnhaverbeke.nl/uglifyjs > $(git rev-parse --show-toplevel)/microfiche.min.js
 git add --all
 git commit
 git co gh-pages


### PR DESCRIPTION
This modifies the push script to use the great service at http://marijnhaverbeke.nl/uglifyjs to minify the script before then adding and committing it again. A minified version is really helpful if trying to get the script submitted to a directory like cdnJS.
