### PR TITLE
Add a 'refresh' method for redrawing Microfiche

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,6 +208,29 @@ $('#autoplay').microfiche({
 
   <script>prettyPrint()</script>
 
+
+  <h3>Refresh</h3>
+
+  <p>To refresh an existing Microfiche's controls and content to adjust to a new container size,
+  call the <code>refresh</code> method directly.</p>
+
+  <div class="demo">
+    <p><pre class="prettyprint">$('#refresher').microfiche().data('microfiche').refresh();</pre></p>
+
+    <script>example('refresher')</script>
+    <script>
+      $('#refresher').microfiche({ cyclic: true });
+    </script>
+    <p>
+      <button onclick="$('#refresher').css('width', '360px'); return false;">Resize Parent &rarr;</button>
+      <code class="prettyprint"> $('#refresher').css('width', '360px');</code>
+      <br />
+      <button onclick="$('#refresher').microfiche().data('microfiche').refresh(); return false;">Refresh &rarr;</button>
+      <code class="prettyprint">$('#refresher').microfiche().data('microfiche').refresh();</code>
+    </p>
+  </div>
+
+
   <hr>
 
   <h2>Changelog</h2>

--- a/microfiche.js
+++ b/microfiche.js
@@ -115,6 +115,9 @@ $.extend(Microfiche.prototype, {
   initialize: function(options) {
     this.options = $.extend({}, this.options, options);
     this.el = $(options.el);
+
+    this.initialContents = this.el.contents();
+
     this.el.data('microfiche', this);
     this.createFilm();
     this.createScreen();
@@ -626,6 +629,28 @@ $.extend(Microfiche.prototype, {
     }, function () {
       self.pause = false;
     });
+  },
+
+  // Refresh the microfiche instance by deleting the contents and associated data,
+  // then restoring the original contents, and re-initializing them. This is particularly
+  // useful for refreshing microfiche on page or container element resize, as it will
+  // redraw the controls if needed.
+  refresh: function() {
+    var options = this.el.data('microfiche').options;
+    var contents = this.el.data('microfiche').initialContents;
+
+    this.cleanContainerForRefresh();
+
+    this.el.append(contents);
+    new Microfiche($.extend({ el: this.el }, options));
+
+    return this.el;
+  },
+
+  cleanContainerForRefresh: function() {
+    this.el.empty();
+    this.el.off();
+    this.el.removeData('microfiche');
   },
 
   // Run given commands, for example:


### PR DESCRIPTION
Specifically useful for updating the Microfiche controls when the page or containing element is resized.

I basically am just storing a copy of the original target DOM element's contents during initialization, so that I can restore them and reinitialize after clearing the existing Microfiche DOM and data elements.

I included an example in the documentation (index.html) page.

What do you think of this approach? Do you think it's enough of a "refresh" to be called "refresh"? And is there a better way of making it callable than $('#my-element').microfiche().data('microfiche').refresh()?

Let me know, happy to further refine if desired.
