### PR TITLE
no-scroll class for microfiche-film

### DIFF
--- a/microfiche.js
+++ b/microfiche.js
@@ -132,7 +132,7 @@ $.extend(Microfiche.prototype, {
 
     if (this.film.width() <= this.screen.width()) {
       // add class to filmstrip if fully visible in its container
-      this.el.find('.microfiche-film').addClass('microfiche-no-scroll');
+      this.film.addClass('microfiche-no-scroll');
       return;
     }
 


### PR DESCRIPTION
add .microfiche-no-scroll class to .microfiche-filmstrip if it fits entirely within the screen container. this will allow styling and positioning of non-scrolling content.
