### PR TITLE
noScrollAlign command

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,19 @@
         '</div>'
       );
     }
+
+    function example_short(id) {
+      document.write(
+        '<div class="example" id="' + id + '">' +
+          '<div>' +
+            '<ul>' +
+              '<li><img src="images/1.jpg" width="160" height="160"></li>' +
+              '<li><img src="images/2.jpg" width="160" height="160"></li>' +
+            '</ul>' +
+          '</div>' +
+        '</div>'
+      );
+    }
   </script>
 </head>
 <body>
@@ -266,6 +279,28 @@ $('.my-slideshow').microfiche({ destroy: true });
 // or
 $('.my-slideshow').data('microfiche').destroy();
     </pre></p>
+
+    <h3>NoScroll Align</h3>
+
+    <p>To define the filmstrip alignment in the event that all items are visible on screen and no scrolling is required, set <code>noScrollAlign</code> to <code>left</code>, <code>center</code>, or <code>right</code>. The default value is <code>left</code>.</p>
+
+    <div class="demo">
+      <p><pre class="prettyprint">
+$('#noscroll').microfiche({ noScrollAlign: 'center' });
+      </pre></p>
+
+      <script>example_short('noscroll')</script>
+      <script>
+        $('#noscroll').microfiche({ noScrollAlign: 'center' });
+      </script>
+
+      <p>
+        <button onclick="$('#noscroll').microfiche({ noScrollAlign: 'left' }); return false;">Run &rarr;</button> <code class="prettyprint">$('#noscroll').microfiche({ noScrollAlign: 'left' })</code><br>
+        <button onclick="$('#noscroll').microfiche({ noScrollAlign: 'center' }); return false;">Run &rarr;</button> <code class="prettyprint">$('#noscroll').microfiche({ noScrollAlign: 'center' })</code><br>
+        <button onclick="$('#noscroll').microfiche({ noScrollAlign: 'right' }); return false;">Run &rarr;</button> <code class="prettyprint">$('#noscroll').microfiche({ noScrollAlign: 'right' })</code><br>
+      </p>
+
+    </div>
 
     <hr>
 

--- a/microfiche.js
+++ b/microfiche.js
@@ -95,6 +95,14 @@
 //    $('my-slideshow').microfiche({ destroy: true });
 //    // or
 //    $('my-slideshow').data('microfiche').destroy();
+//
+// ### noScrollAlign
+//
+// Defines left, right, or center filmstrip alignment in the event that
+// all items are visible on screen and no scrolling is required.
+//
+//    $('.my-slideshow').microfiche({ noScrollAlign: 'left' });
+//
 
 (function() {
 
@@ -124,7 +132,8 @@ $.extend(Microfiche.prototype, {
     swipeThreshold  : 0.125,
     refreshOnResize : false,
     prevButtonLabel : '&larr;',
-    nextButtonLabel : '&rarr;'
+    nextButtonLabel : '&rarr;',
+    noScrollAlign   : 'left'
   },
 
   // Rather than relying on the literal position of `this.film`,
@@ -146,7 +155,10 @@ $.extend(Microfiche.prototype, {
     this.createScreen();
     this.calibrate();
 
-    if (this.film.width() <= this.screen.width()) return;
+    if (this.film.width() <= this.screen.width()) {
+      this.noScrollAlign(this.options.noScrollAlign);
+      return;
+    }
 
     this.createControls();
     this.enableTouch();
@@ -718,6 +730,36 @@ $.extend(Microfiche.prototype, {
 
   clearResizeHandler: function() {
     $(window).off('resize', this.resizeHandler);
+  },
+
+  noScrollAlign: function(alignment) {
+    if(this.film.width() > this.screen.width()) return;
+
+    switch(alignment) {
+      case 'center':
+        this.film.css({ 
+          left: '50%',
+          marginLeft: (this.film.width() / 2 * -1) + 'px', 
+          right: 'auto'
+        });
+        break;
+
+      case 'right':
+        this.film.css({ 
+          left: 'auto',
+          marginLeft: 'auto',
+          right: 0 
+        });
+        break;
+
+      default:
+        this.film.css({ 
+          left: 0,
+          marginLeft: 'auto',
+          right: 'auto' 
+        });
+    }
+
   },
 
   // Run given commands, for example:


### PR DESCRIPTION
Added noScrollAlign command which defines `left`, `right`, or `center` filmstrip alignment in the event that all items are visible on screen and no scrolling is required.

Have not yet tested on IE.
