### PR TITLE
Rename cleanContainerForRefresh to destroy

### DIFF
--- a/microfiche.js
+++ b/microfiche.js
@@ -647,7 +647,7 @@ $.extend(Microfiche.prototype, {
     });
   },
 
-  // Destroy the microfiche instance and clear its contents
+  // Destroy the microfiche instance and clear related events
   destroy: function() {
     this.el.empty();
     this.el.off();


### PR DESCRIPTION
and clean up resize events there instead of in resizeOnRefresh
