### PR TITLE
Fix resizeOnRefresh bug which prevented refresh when film < screen

### DIFF
--- a/microfiche.demo.css
+++ b/microfiche.demo.css
@@ -113,6 +113,5 @@ hr {
 
 .body-subcontainer.responsive-width-demo {
   width: auto;
-  max-width: 980px;
   min-width: 315px;
 }

--- a/microfiche.js
+++ b/microfiche.js
@@ -157,6 +157,7 @@ $.extend(Microfiche.prototype, {
 
     if (this.film.width() <= this.screen.width()) {
       this.noScrollAlign(this.options.noScrollAlign);
+      this.refreshOnResize(this.options.refreshOnResize);
       return;
     }
 


### PR DESCRIPTION
because `this.run(this.options);` never gets called when film width < screen width, the window resize handler never gets set. this affects both initial load and any refresh states, so resizeOnRefresh will always stop functioning whenever film < screen.

this PR adds the resizeOnRefresh handler in the event that film < screen, and removes the width limit for that example on the demo page so that it's easy to demonstrate and test.
