### PR TITLE
 - Fix issue where if a last page < 50% width, pressing the back will…

### DIFF
--- a/microfiche.js
+++ b/microfiche.js
@@ -582,7 +582,7 @@ $.extend(Microfiche.prototype, {
     var ox = this.x,
          w = this.screenWidth();
 
-    this.x = this.constrain((Math.round(this.x / w) + n) * w);
+    this.x = this.constrain(Math.round(((this.x / w) + n) * w));
 
     if (this.options.cyclic && this.x == ox) this.x += n * w;
 


### PR DESCRIPTION
… jump upto 150% of a slide, which is effectively two pages (due to rounding issue).

Hey, I've been using microfiche and came across an issue - let me explain. We have a navigation bar which is 800px wide, and each item is 200px wide, so we can have up to 4 per page. We had 13 items in our list, so there are 4 pages. When we used the 'next' and 'previous' buttons, using 'next' was fine, so we could go 1-2-3-4, but using previous went 4-2-1. This is due to a rounding issue where if you have less than 50% used on the last slide, the code will ignore that (round it off) and jump an entire page PLUS what is on that final semi-full page (so for us it was jumping 5 items and messing up our page counter - i notice that the max() function has already been fixed in the unreleased v1.8.1).

I was using V1.8.0 when I fixed this.

Thanks,
Alex